### PR TITLE
Updated TLS version < 1.2 unsupported by twitter July 15, 2019

### DIFF
--- a/Samples/TwitterClient/TwitterClient.Common/Entities/TwitterData.cs
+++ b/Samples/TwitterClient/TwitterClient.Common/Entities/TwitterData.cs
@@ -155,7 +155,8 @@ namespace TwitterClient.Common
 
             // make the request
             ServicePointManager.Expect100Continue = false;
-
+            // updating TLS version "TLS  <  1.2 is unsupported by  Tweeter starting July 15, 2019"
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
             var postBody = "track=" + HttpUtility.UrlEncode(config.Keywords);
             resource_url += "?" + postBody;
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(resource_url);


### PR DESCRIPTION
Hello team, I updated the TLS version following Ivan's fix and suggestion. This will fix the unsupported version issue.