### PR TITLE
Update TelcoDataGenerator framework version from 452 to 472

### DIFF
--- a/DataGenerators/TelcoGenerator/app.config
+++ b/DataGenerators/TelcoGenerator/app.config
@@ -5,7 +5,7 @@
     <add key="EventHubName" value="***ENTER YOUR EVENT HUB NAME***"/>
     <add key="Microsoft.ServiceBus.ConnectionString" value="***ENTER YOUR KEY***"/>
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup>
 <system.serviceModel>
 <extensions>
 <!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->

--- a/DataGenerators/TelcoGenerator/telcodatagen.csproj
+++ b/DataGenerators/TelcoGenerator/telcodatagen.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>telcodatagen</RootNamespace>
     <AssemblyName>telcodatagen</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Samples/TelcoGenerator/TelcoDataGenerator.Common/TelcoDataGenerator.Common.csproj
+++ b/Samples/TelcoGenerator/TelcoDataGenerator.Common/TelcoDataGenerator.Common.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TelcoDataGenerator.Common</RootNamespace>
     <AssemblyName>TelcoDataGenerator.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Samples/TelcoGenerator/app.config
+++ b/Samples/TelcoGenerator/app.config
@@ -5,7 +5,7 @@
     <add key="EventHubName" value="***ENTER YOUR EVENT HUB NAME***"/>
     <add key="Microsoft.ServiceBus.ConnectionString" value="***ENTER YOUR KEY***"/>
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup>
 <system.serviceModel>
 <extensions>
 <!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->

--- a/Samples/TelcoGenerator/telcodatagen.csproj
+++ b/Samples/TelcoGenerator/telcodatagen.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>telcodatagen</RootNamespace>
     <AssemblyName>telcodatagen</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>


### PR DESCRIPTION
- The old TelcoGenerator project was based on .net framework 451/452 which can't work with TLS 1.2.
- Update TelcoDataGenerator framework version from 451/452 to **472** which could work well with TLS 1.2.