### PR TITLE
Config fails to load the connection string causing 401 errors

### DIFF
--- a/Samples/TwitterClient/TwitterClient/EventHubObserver.cs
+++ b/Samples/TwitterClient/TwitterClient/EventHubObserver.cs
@@ -24,7 +24,6 @@ namespace TwitterClient
     public class EventHubObserver : IObserver<Payload>
     {
         private EventHubConfig _config;
-        private EventHubClient _eventHubClient;
         public bool AzureOn { get; set; }
                 
         public EventHubObserver(EventHubConfig config, bool azureOn = true)
@@ -36,7 +35,7 @@ namespace TwitterClient
                 _config = config;
 				if (AzureOn)
 				{
-					_eventHubClient = EventHubClient.CreateFromConnectionString(_config.ConnectionString, config.EventHubName);
+					_eventHubClient = EventHubClient.CreateFromConnectionString(config.ConnectionString, config.EventHubName);
 				}
             }
             catch (Exception ex)


### PR DESCRIPTION
when initiating the EventHubObserver we are passing the EventHubConfig object, on the observer we are not initiating the values, need to fix the initiator and remove the _config variable from the class as it is not used anywhere.

this could be related to issue #149 
https://github.com/Azure/azure-stream-analytics/issues/149